### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled command line

### DIFF
--- a/WebGoat/App_Code/Util.cs
+++ b/WebGoat/App_Code/Util.cs
@@ -13,6 +13,7 @@ namespace OWASP.WebGoat.NET.App_Code
         
         public static int RunProcessWithInput(string cmd, string args, string input)
         {
+            args = ValidateArgs(args);
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = Settings.RootDir,
@@ -89,6 +90,17 @@ namespace OWASP.WebGoat.NET.App_Code
                 }
             }
         }
+        private static string ValidateArgs(string args)
+        {
+            // Allow only alphanumeric characters, spaces, and a few special characters
+            foreach (char c in args)
+            {
+                if (!char.IsLetterOrDigit(c) && c != ' ' && c != '-' && c != '_' && c != '.')
+                {
+                    throw new ArgumentException("Invalid character in arguments");
+                }
+            }
+            return args;
+        }
     }
 }
-


### PR DESCRIPTION
Potential fix for [https://github.com/jmarti326/demo-csharp/security/code-scanning/21](https://github.com/jmarti326/demo-csharp/security/code-scanning/21)

To fix the problem, we need to validate and sanitize the user input before using it in the `ProcessStartInfo.Arguments`. One way to achieve this is by using a whitelist approach, where only known safe commands and arguments are allowed. Alternatively, we can escape any potentially dangerous characters in the user input to prevent command injection.

The best way to fix the problem without changing existing functionality is to add a method that validates the `args` parameter and ensure it only contains safe characters. We will modify the `RunProcessWithInput` method to call this validation method before setting the `Arguments` property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
